### PR TITLE
Detect when no audio is available

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,12 @@
+var audioUrls = {};
+
+function hide(tabId) {
+  chrome.pageAction.setTitle({
+    title: "No audio available",
+    tabId
+  });
+}
+
 chrome.runtime.onInstalled.addListener(function() {
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
     chrome.declarativeContent.onPageChanged.addRules([
@@ -13,28 +22,29 @@ chrome.runtime.onInstalled.addListener(function() {
   });
 });
 
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+  if (changeInfo.status == 'complete') {
+  var url = tab.url;
+  var id = url.split("-").pop();
+  if (undefined !== id && url.startsWith('https://medium.com/')) {
+    var request = new XMLHttpRequest();
+    request.open("GET", "https://medium.com/p/" + id + "/notes", true);
+    request.onload = function() {
+      if (request.status === 200) {
+        var resp = request.responseText;
+        var match = resp.match(/\"audioVersionUrl\":\"([^"]+)\"/);
+        if (null !== match && null !== match[1]) {
+          var audioUrl = match[1];
+          audioUrls[tabId] = audioUrl;
+        } else hide(tabId)
+      } else hide(tabId);
+    };
+    request.send();
+  } else hide(tabId);
+}
+});
+
 chrome.pageAction.onClicked.addListener(function(tab) {
-  chrome.tabs.query({
-    active: true,
-    lastFocusedWindow: true
-  }, function(array_of_tabs) {
-    var tab = array_of_tabs[0];
-    var url = tab.url;
-    var id = url.split("-").pop();
-    if (undefined !== id) {
-      var request = new XMLHttpRequest();
-      request.open("GET", "https://medium.com/p/" + id + "/notes", true);
-      request.onload = function() {
-        if (request.status === 200) {
-          var resp = request.responseText;
-          var match = resp.match(/\"audioVersionUrl\":\"([^"]+)\"/);
-          if (null !== match && null !== match[1]) {
-            var audioUrl = match[1];
-            chrome.tabs.create({"url": audioUrl});
-          }
-        }
-      };
-      request.send();
-    }
-  });
+  var url = audioUrls[tab.id];
+  if (url) chrome.tabs.create({url});
 });

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,9 @@
     },
     "permissions": [
         "activeTab",
-        "declarativeContent"
+        "declarativeContent",
+        "tabs",
+        "https://medium.com/"
     ],
     "icons": {
         "16": "icon16.png",


### PR DESCRIPTION
Addresses issue #3 
In agreement with https://bugs.chromium.org/p/chromium/issues/detail?id=429603#c2, chrome.pageAction.hide seems to have no affect. Instead, this PR checks for audio and changes the tooltip if none is found.